### PR TITLE
namex 0.1.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,17 @@
 {% set name = "namex" %}
-{% set version = "0.0.7" %}
+{% set version = "0.1.0" %}
 
 package:
-  name: "{{ name|lower }}"
-  version: "{{ version }}"
+  name: {{ name|lower }}
+  version: {{ version }}
 
 source:
-  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: 84ba65bc4d22bd909e3d26bf2ffb4b9529b608cb3f9a4336f776b04204ced69b
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 117f03ccd302cc48e3f5c58a296838f6b89c83455ab8683a1e85f2a430aa4306
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
@@ -29,6 +29,7 @@ test:
     - pip
   commands:
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
 
 about:
   home: https://github.com/fchollet/namex


### PR DESCRIPTION
namex 0.1.0 

**Destination channel:** Defaults

### Links

- [PKG-9275]
- dev_url:        https://github.com/fchollet/namex/tree/main
- conda_forge:    None
- pypi:           https://pypi.org/project/namex/0.1.0
- pypi inspector: https://inspector.pypi.io/project/namex/0.1.0

### Explanation of changes:

- new version number


[PKG-9275]: https://anaconda.atlassian.net/browse/PKG-9275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ